### PR TITLE
Fix .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,17 +1,7 @@
 # A set of files and folders I don't want in my WordPress.org SVN repo:
-
-```gitattributes
-/.git export-ignore
 /.github export-ignore
-/node_modules export-ignore
-/src export-ignore
 /.wordpress-org export-ignore
-/.github/workflows export-ignore
-/.distignore export-ignore
 /.eslintrc.js export-ignore
+/.gitattributes export-ignore
 /.gitignore export-ignore
-/Makefile export-ignore
-/package.json export-ignore
-/package-lock.json export-ignore
 /readme.md export-ignore
-```


### PR DESCRIPTION
gitattributes works on git index, not on the filesystem

These were files not committes to git
```
/.distignore export-ignore
/Makefile export-ignore
/package.json export-ignore
/package-lock.json export-ignore
/node_modules export-ignore
/src export-ignore
```
