### PR TITLE
Update autoload.php - Fix: Initialize $file to prevent undefined variable error

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -17,6 +17,7 @@ spl_autoload_register(
  */
     function($class)
 {
+	$file = null; // This ensures the variable is defined (added by Robert Frischke 12/07/2025 to resolve undefined variable error)
     switch ($class) {
         case 'WeatherStation\Data\Arrays\Generator': $file = LWS_INCLUDES_DIR.'traits/DataArraysGenerator.php'; break;
         case 'WeatherStation\Data\Dashboard\Handling': $file = LWS_INCLUDES_DIR.'traits/DataDashboardHandling.php'; break;


### PR DESCRIPTION
This PR fixes an undefined variable error in autoload.php by explicitly initializing $file = null; before the switch ($class) statement.

Prevents “undefined variable $file” notices when loading certain classes.

Keeps behavior identical, just ensures the variable is always defined.

Tested with plugin in a WordPress environment, error no longer occurs.