### PR TITLE
docs: clarify sponsorship impact incl. hardware purchase/upgrades for broader testing

### DIFF
--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -6,6 +6,8 @@ Thank you to all the amazing people and organizations who support Weather Statio
 
 If your company, or the organization you work for, uses the Weather Station plugin, consider sponsoring its development. Corporate sponsorship helps ensure the plugin's long-term maintenance and development of new features that benefit the entire community.
 
+Corporate and individual sponsorship also helps purchase or upgrade weather station hardware for comprehensive testing, since the maintainer does not own test devices for every brand/model.
+
 Any questions? Contact: bonjour@jasonrouet.com
 
 ---

--- a/readme.md
+++ b/readme.md
@@ -73,11 +73,12 @@ Weather Station is **completely free and open source**. However, maintaining and
 
 ### How Your Support Helps
 Your sponsorship enables me to:
-- Dedicate time regularly on plugin improvements and new features
 - Maintain security updates and WordPress compatibility
-- (Optionally) Hire external contributors for specialized tasks
+- Purchase or upgrade weather station hardware for testing (the maintainer does not own devices for every brand/model)
+- Test across a wide range of weather station models and services
+- Deliver new features and continuous improvements
 - Improve documentation and user support
-- Test with various weather station models
+- (Optionally) Hire external contributors for specialized tasks
 
 ### Ways to Support
 - **[GitHub Sponsors](https://github.com/sponsors/jaz_on)** - Recurring monthly support

--- a/readme.txt
+++ b/readme.txt
@@ -65,7 +65,13 @@ This plugin is free and provided without warranty of any kind. Use it at your ow
 = Support the Development =
 Weather Station is completely free and open source, but your support helps maintain and improve it!
 
-Your sponsorship enables regular development, security updates, and hiring external contributors for specialized tasks.
+Your sponsorship enables:
+- Security updates and WordPress compatibility
+- Purchase or upgrade of weather station hardware for testing (the maintainer does not own devices for every brand/model)
+- Testing across a wide range of station models and services
+- New features and continuous improvements
+- Better documentation and user support
+- Optional external contributors for specialized tasks
 
 - GitHub Sponsors: https://github.com/sponsors/jaz_on
 - Ko-fi: https://ko-fi.com/jasonrouet


### PR DESCRIPTION
This PR updates documentation to clarify how sponsorships are used, specifically to:

- Maintain security updates and WordPress compatibility
- Deliver new features and continuous improvements
- Purchase or upgrade weather station hardware to test a wider range of models and services (the maintainer does not own devices for every brand/model)
- Improve documentation and user support
- Optionally hire external contributors for specialized tasks

Files updated:
- readme.md: revised "How Your Support Helps"
- readme.txt: reorganized "Support the Development" block
- SPONSORS.md: added precision about hardware purchases/upgrades for testing

Rationale:
- Make funding usage explicit, especially for hardware acquisition and upgrades to broaden test coverage across brands/models.
- Keep wording consistent across public docs.

Follow-ups:
- Add an "Unreleased" note in changelog.txt referencing this clarification.
- Mirror the updated wording on the project website/handbook if applicable.
