### PR TITLE
security: fix residual SQLi, anonymous shortcode bypass, missing capability check

### DIFF
--- a/admin/partials/FormDeleteMap.php
+++ b/admin/partials/FormDeleteMap.php
@@ -11,7 +11,7 @@ if (!($mid = filter_input(INPUT_GET, 'mid'))) {
 }
 if (isset($mid) && $mid) {
     $map = $this->get_map_detail($mid);
-    $params = unserialize($map['params']);
+    $params = unserialize($map['params'], array('allowed_classes' => false));
     $map_name = $map['name'];
     $map_location = $this->output_coordinate($params['common']['loc_latitude'], 'loc_latitude', 5, true);
     $map_location .= ' ⁛ ' . $this->output_coordinate($params['common']['loc_longitude'], 'loc_longitude', 5, true);

--- a/includes/classes/StationHelper.php
+++ b/includes/classes/StationHelper.php
@@ -252,6 +252,10 @@ class Handling {
      * @since 3.0.0
      */
     public function edit_station() {
+        if (!current_user_can(apply_filters('lws_manage_options_capability', 'manage_options'))) {
+            Logger::critical('Security', null, null, null, null, null, 0, 'Unauthorized attempt to edit a station.');
+            return;
+        }
         if ($this->arg_service == 'station' && $this->arg_tab == 'view' && $this->arg_action == 'manage') {
             $station = array();
             if (array_key_exists('_wpnonce', $_POST)) {

--- a/includes/traits/DBQuery.php
+++ b/includes/traits/DBQuery.php
@@ -1251,7 +1251,7 @@ trait Query {
     protected function get_map_detail($id) {
         global $wpdb;
         $table_name = $wpdb->prefix . self::live_weather_station_maps_table();
-        $sql = "SELECT * FROM " . $table_name . " WHERE id='" . $id . "';";
+        $sql = $wpdb->prepare("SELECT * FROM " . $table_name . " WHERE id=%d;", intval($id));
         try {
             $result = $wpdb->get_results($sql, ARRAY_A);
             if (count($result) > 0) {
@@ -2586,7 +2586,7 @@ trait Query {
     protected function get_log_detail($log_entry) {
         global $wpdb;
         $table_name = $wpdb->prefix.self::live_weather_station_log_table();
-        $sql = "SELECT * FROM " . $table_name . " WHERE id=" . $log_entry ;
+        $sql = $wpdb->prepare("SELECT * FROM " . $table_name . " WHERE id=%d", intval($log_entry));
         try {
             $query = (array)$wpdb->get_results($sql);
             $query_a = (array)$query;

--- a/public/SystemPluginFrontend.php
+++ b/public/SystemPluginFrontend.php
@@ -409,10 +409,8 @@ class Frontend {
             $shortcode = '[' . $shortcode . ']';
         }
         $allowed = false;
-        foreach ($this->allowed_shortcodes as $allowed_shortcode) {
-            if (strpos($shortcode, '[' . $allowed_shortcode . ' ') === 0) {
-                $allowed = true;
-            }
+        if (substr_count($shortcode, '[') === 1 && preg_match('/^\[([a-z0-9_-]+)\b/i', $shortcode, $tag_match)) {
+            $allowed = in_array($tag_match[1], $this->allowed_shortcodes, true);
         }
         if ($allowed) {
             exit(do_shortcode($shortcode));


### PR DESCRIPTION
Phase 0 de la feuille de route issue de l'audit structurel (2026-09) — suite du travail de PR #48, sur les points qu'elle avait manqués.

## Changements
- `DBQuery::get_map_detail()` / `get_log_detail()` : requêtes préparées + `intval()` au lieu de concaténation directe.
- `SystemPluginFrontend::lws_shortcode_callback()` : la whitelist ne vérifiait que le préfixe du shortcode envoyé en AJAX (endpoint accessible aux visiteurs anonymes), ce qui permettait d'en faire exécuter un autre à la suite. Vérifie maintenant le nom exact, un seul shortcode par appel.
- `StationHelper::edit_station()` : ajout du contrôle `current_user_can()` présent sur toutes les autres actions admin.
- `FormDeleteMap.php` : `unserialize()` avec `allowed_classes => false`.

## Suivi
Tracké en privé : Weather-Station-Software/internal#1, #2

## Tests
Aucune suite de tests n'existe encore sur ce dépôt (voir phase 1/3 de la roadmap) — vérifié par `php -l` sur les 4 fichiers modifiés, et relecture manuelle du comportement attendu.